### PR TITLE
ENH: Add broadcast.ndim to match code elsewhere

### DIFF
--- a/numpy/core/src/multiarray/iterators.c
+++ b/numpy/core/src/multiarray/iterators.c
@@ -1696,6 +1696,10 @@ static PyMemberDef arraymultiter_members[] = {
         T_INT,
         offsetof(PyArrayMultiIterObject, nd),
         READONLY, NULL},
+    {"ndim",
+        T_INT,
+        offsetof(PyArrayMultiIterObject, nd),
+        READONLY, NULL},
     {NULL, 0, 0, 0, NULL},
 };
 


### PR DESCRIPTION
`broadcast.nd` is an unusual name, but needs to be left for compatibility

Both `ndarray` and `nditer` call it `ndim`, so broadcast objects should too.
